### PR TITLE
Increase port field width in connection dialog

### DIFF
--- a/src/main/java/com/shinyhut/vernacular/VernacularViewer.java
+++ b/src/main/java/com/shinyhut/vernacular/VernacularViewer.java
@@ -301,7 +301,7 @@ public class VernacularViewer extends JFrame {
         JPanel connectDialog = new JPanel();
         JTextField hostField = new JTextField(20);
         hostField.addAncestorListener(focusRequester);
-        JTextField portField = new JTextField("5900");
+        JTextField portField = new JTextField("5900", 4);
         JLabel hostLabel = new JLabel("Host");
         hostLabel.setLabelFor(hostField);
         JLabel portLabel = new JLabel("Port");


### PR DESCRIPTION
When using the application I noticed that  in the connection dialog, the the field for the port value is just wide enough for port numbers having the same length as the default value of 5900. But ports can have more than four digits. 
![image](https://user-images.githubusercontent.com/2690120/224926553-d1f39ed2-8862-4d7b-83c6-4017d5bc99ba.png)

Setting the columns in the constructor to 4 makes it possible to see six digits in the field, which is more than enough.
![image](https://user-images.githubusercontent.com/2690120/224924858-e387c445-2632-4427-a31e-b6a4a4bf87ee.png)

Note that setting the columns to 3 is not enough, as the fifth digit is only halfway visible.
![image](https://user-images.githubusercontent.com/2690120/224925014-fad25bdd-0472-46a0-b0c4-fe269ddb47d4.png)
